### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,12 @@ export function get (object, path, def) {
   }, object)) === undefined ? def : object;
 };
 
-export function set  (object, path, val, obj) {
+export function set (object, path, val, obj) {
   return ((path = path.split ? path.split('.') : path.slice(0)).slice(0, -1).reduce(function (obj, p) {
-    return obj[p] = obj[p] || {};
+    return obj[p] = isPrototypePolluted(p) || obj[p] || {};
   }, obj = object)[path.pop()] = val), object;
 };
+
+function isPrototypePolluted (key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
+}


### PR DESCRIPTION
### :bar_chart: Metadata *

`shvl` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-shvl

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var shvl = require("shvl")
let obj = {}
console.log("Before: " + {}.polluted)
shvl.set(obj, '__proto__.polluted', 'Yes! Its Polluted')
console.log("After: " + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i shvl # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![shvl-fix](https://user-images.githubusercontent.com/43996156/103162980-b9007b00-481d-11eb-98c3-dcb167fbd304.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
